### PR TITLE
Handle errors (e.g. couchdb server down)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,9 @@ export default function couchdbAuthProxy(fn, opts={}) {
 				if (secret) req.headers[token] = sign(n, secret);
 			}
 
-			proxy.web(req, res);
+			proxy.web(req, res, {}, e => {
+			  next(e);
+			});
 		} catch(e) {
 			if (next) next(e);
 			else throw e;


### PR DESCRIPTION
Necessary to catch errors due to connection issue to couchdb instance. Errors can then be caught by something like 

```
app.use((err, req, res, next) => {
  console.error(err.stack);
  res.status(500).send('Something broke!');
});
```

If you accept this PR, I'd be super-grateful about a new version publish :)

Thanks for the great work.

ps. It would've been even a greater experience if this repo had provided a couchdb config file, something (feel free to add it to readme!) like:

```
[chttpd]
bind_address = any
port = 5984
authentication_handlers = {couch_httpd_auth, proxy_authentication_handler}, {couch_httpd_auth, cookie_authentication_handler}, {couch_httpd_auth, default_authentication_handler}

[httpd]
bind_address = any

[couch_httpd_auth]
proxy_use_secret = true
secret = SOME_SECRET
```

Its easy to confuse the httpd and chttpd section of authentication_handlers.